### PR TITLE
list of fixes

### DIFF
--- a/examples/llama_index/flagembedding/finetuning.py
+++ b/examples/llama_index/flagembedding/finetuning.py
@@ -9,7 +9,7 @@ import langrunner
 FlagEmbeddingFinetuneEngine = langrunner.runnable(FlagEmbeddingFinetuneEngine)
 finetune_engine = FlagEmbeddingFinetuneEngine(
         model_name_or_path="BAAI/bge-large-zh-v1.5",
-        train_data="data.jsonl",
+        train_data="./data.jsonl",
         output_dir="ft_emb_model")
 
 finetune_engine.finetune()

--- a/examples/llama_index/sentence_transformers/finetuning.py
+++ b/examples/llama_index/sentence_transformers/finetuning.py
@@ -20,5 +20,3 @@ finetune_engine = SentenceTransformersFinetuneEngine(
     val_dataset=val_dataset,
 )
 finetune_engine.finetune()
-embed_model = finetune_engine.get_finetuned_model()
-print(embed_model)

--- a/examples/llama_index/sft/sft_output
+++ b/examples/llama_index/sft/sft_output
@@ -1,1 +1,0 @@
-/home/ahmed-khan/./langrunner/55ed6ca3-964f-41c1-8d05-fbe686c16f1b/output

--- a/langrunner/llama_index/sft.py
+++ b/langrunner/llama_index/sft.py
@@ -19,11 +19,12 @@ class SFTFinetuneEngineRemote(RemoteRunnable, SFTFinetuneEngine):
         context = get_current_context()
 
         train_dataset = context.langclass_initparams['train_dataset']
+        '''
         if os.path.isfile(train_dataset):
             fname = os.path.basename(self.train_dataset)
             target_file = os.path.join("/mnt/input", fname)
             context.langclass_initparams['train_dataset'] = target_file
-
+        '''
         context.langclass_initparams['output_dir'] = "/mnt/output"
         finetune_engine = SFTFinetuneEngine(**context.langclass_initparams)
         finetune_engine.finetune()
@@ -35,7 +36,9 @@ class SFTFinetuneEngineRemote(RemoteRunnable, SFTFinetuneEngine):
             # create sym link in context.inputdir
             fname = os.path.basename(self.train_dataset)
             target_file = os.path.join(context.inputdir, fname)
-            os.symlink(target_file, self.train_dataset)
+            os.symlink(f"{os.getcwd()}/{self.train_dataset}", target_file)
+            # this is where the file is going to get mounted inside sky task
+            context.langclass_initparams['train_dataset'] = os.path.join("/mnt/input", fname)
 
         model_dir = self.output_dir
         if os.path.islink(model_dir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-skypilot[aws,gcp,kubernetes]
+skypilot[aws,gcp,kubernetes]==0.6.1
+mistralai==0.4.2
+yaspin==3.0.2
 unique-names-generator
 dill
-mistralai==0.4.2


### PR DESCRIPTION
- Fixed flag embedding example to use correct path for sample data jsonl file
- Fixed the flagembedding trainer code to fix the FE package version and fix to update init params to reflect the correct mount point
- Fix in sft to properly update the train dataset path in init params
- Fixed the path references in sft trainer to reflect the correct paths for mounted train dataset and generated finetuned adapter + merged model.
- atexit function to gracefully teardown all the sky resources including services and clusters. support to pass location of creds file with env var LANGRUNNER_CREDS_FILEPATH
- added missing deps in requirements.txt